### PR TITLE
fix(server):Drop duplicate identifier causing typedoc to fail output

### DIFF
--- a/src/server/servers/abstract.server.ts
+++ b/src/server/servers/abstract.server.ts
@@ -1,4 +1,3 @@
-import { IRouteConfiguration } from 'hapi';
 import { Injectable } from '@angular/core';
 import { RemoteCli } from '../services/remoteCli.service';
 import { Logger } from '../../common/services/logger.service';


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change
