### PR TITLE
hotfix(docs): Hide api docs while typedoc is non-functional

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -4,7 +4,8 @@ date: 2016-05-29
 collection: main
 collectionSort: 1
 layout: api-container.hbs
----
+draft: true
+-----------
 
 ## Error
 Typedoc output not found. Have you run the generator?


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change
