### PR TITLE
chore(docs): Add email github task link

### DIFF
--- a/docs/guide/email.md
+++ b/docs/guide/email.md
@@ -5,5 +5,5 @@ date: 2016-06-09
 collection: guide
 collectionSort: 1
 layout: guide.hbs
-pendingTask: true
+pendingTask: https://github.com/ubiquits/ubiquits/issues/74
 ---


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change
