### PR TITLE
fix(deploy): Fix npmignore to include the root lib dirs

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,16 +1,11 @@
-
 #ignore all
 /*
-# add lib output
-!/lib/**
-# remove lib maps
-/lib/**/*.map
 
 !/docker/**
-
-# root js files
-!/*.js
-!/*.d.ts
+!/common/**
+!/browser/**
+!/server/**
+!/index.*
 
 # root docs
 #!/README.md


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change
