### PR TITLE
fix(deployment): Fix typedoc documentation not deploying

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "coveralls": "u coveralls",
     "build": "u build",
     "preparepublish": "u build && cp -r lib/* .",
-    "postpublish": "u changelog && u doc build && u deploy docs"
+    "postpublish": "u changelog && u doc build && u typedoc && u deploy docs"
   },
   "repository": {
     "type": "git",
@@ -71,7 +71,7 @@
     "zone.js": "^0.6.12"
   },
   "devDependencies": {
-    "@ubiquits/toolchain": "^0.3.0",
+    "@ubiquits/toolchain": "^0.3.1",
     "proxyquire": "^1.7.10"
   },
   "directories": {

--- a/src/common/util/banner.ts
+++ b/src/common/util/banner.ts
@@ -1,8 +1,9 @@
-import * as chalk from 'chalk';
 /**
  * @module common
  */
 /** End Typedoc Module Declaration */
+
+import * as chalk from 'chalk';
 
 /**
  * Ubiquits Banner for usage in cli welcome

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,8 @@
+/**
+ * This is the module root, it *should not* be used as a root point to import from.
+ * @module common
+ */
+/** End Typedoc Module Declaration */
 export * from './browser';
 export * from './common';
 export * from './server';


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change
